### PR TITLE
Update cli_docs.mdx - fix broken link to config log10 env vars

### DIFF
--- a/pages/cli_docs.mdx
+++ b/pages/cli_docs.mdx
@@ -5,7 +5,7 @@ Here's a [demo video](https://www.loom.com/share/4f5da34df6e94b7083b1e33c707deb5
 
 ## Get Started
 
-Install the `log10-io` python package (version >= 0.6.7) and [setup Log10](README.md#⚙️-setup)
+Install the `log10-io` python package (version >= 0.6.7) and [setup Log10](https://docs.log10.io/observability/advanced/logging#configuration)
 
 ```bash
 $ pip install 'log10-io[cli]'


### PR DESCRIPTION
pointed the "setup log10" to the "[configuration](https://docs.log10.io/observability/advanced/logging#configuration)" in advanced logging in the docs. 
And verified the link works in preview. 