### PR TITLE
Fix evaluation link

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,17 @@ const withNextra = require("nextra")({
   themeConfig: "./theme.config.jsx",
 });
 
-module.exports = withNextra();
+module.exports = withNextra({
+  async redirects() {
+    return [
+      {
+        destination: "/evaluation",
+        permanent: true,
+        source: "/evaluation/installation",
+      },
+    ];
+  },
+});
 
 // If you have other Next.js configurations, you can pass them as the parameter:
 // module.exports = withNextra({ /* other next.js config */ })

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -50,6 +50,6 @@ Depending on whether you want to start with LLM observabiliy, or LLM evaluation 
   <Card
     icon={<CheckBadgeIcon />}
     title="Evaluation"
-    href="/evaluation/installation"
+    href="/evaluation"
   />
 </Cards>

--- a/pages/notebooks.mdx
+++ b/pages/notebooks.mdx
@@ -45,6 +45,6 @@ Depending on whether you want to start with LLM observabiliy, or LLM evaluation 
   <Card
     icon={<CheckBadgeIcon />}
     title="Evaluation"
-    href="/evaluation/installation"
+    href="/evaluation"
   />
 </Cards>


### PR DESCRIPTION
Old llmeval (installation) page moved.

 - Redirect /evaluation/installation to /evaluation (to get old llmeval links to the new one). Consider redirecting to the old one.
 - Fix bottom link on two pages